### PR TITLE
UIP_CONF_IPV6=0 should not enable ipv6

### DIFF
--- a/platform/wsn430/Makefile.common
+++ b/platform/wsn430/Makefile.common
@@ -20,7 +20,7 @@ ifndef CONTIKI_TARGET_MAIN
 CONTIKI_TARGET_MAIN = contiki-wsn430-main.c
 endif
 
-ifdef UIP_CONF_IPV6
+ifeq ($(UIP_CONF_IPV6),1)
 CFLAGS += -DWITH_UIP6=1
 endif
 


### PR DESCRIPTION
UIP_CONF_IPV6=0 does not enable ipv6 functionality. The used check for the makefile flag is not consistent to the native contiki platforms.