### PR TITLE
GCC-5 Compat: uart1_get_input_handler inline

### DIFF
--- a/platform/openlab/dev/uart1.c
+++ b/platform/openlab/dev/uart1.c
@@ -1,16 +1,15 @@
+
+/* Inline function management, see header. */
+#define INLINE
 #include "dev/uart1.h"
+
 #include "dev/serial-line.h"
 
 /* serial line byte input handler interface (dev/uart1.h)
  * default handler = serial_line_input_byte (Contiki's default behaviour)
  */
-static int (*uart1_input_handler) (unsigned char) = serial_line_input_byte;
+int (*uart1_input_handler) (unsigned char) = serial_line_input_byte;
 void uart1_set_input(uart_input_handler_t input)
 {
     uart1_input_handler = input;
-}
-
-inline uart_input_handler_t uart1_get_input_handler()
-{
-    return uart1_input_handler;
 }

--- a/platform/openlab/dev/uart1.h
+++ b/platform/openlab/dev/uart1.h
@@ -28,6 +28,24 @@
  */
 
 #define BAUD2UBR(baud) baud
+
+/* Multiple version inline management
+ * http://www.greenend.org.uk/rjk/tech/inline.html
+ */
+#ifndef INLINE
+# if __GNUC__ && !__GNUC_STDC_INLINE__
+#  define INLINE extern inline
+# else
+#  define INLINE inline
+# endif
+#endif
+
+extern int (*uart1_input_handler) (unsigned char);
+
 typedef int (*uart_input_handler_t)(unsigned char);
 void uart1_set_input(uart_input_handler_t input);
-inline uart_input_handler_t uart1_get_input_handler();
+
+INLINE uart_input_handler_t uart1_get_input_handler()
+{
+    return uart1_input_handler;
+}


### PR DESCRIPTION
Modify the way uart1_get_input_handler inline management is done to work for
both gcc4 and gcc5.